### PR TITLE
Add `@rpath` patch for OS X

### DIFF
--- a/recipe/PR_1965.diff
+++ b/recipe/PR_1965.diff
@@ -1,0 +1,20 @@
+diff --git PyInstaller/depend/bindepend.py PyInstaller/depend/bindepend.py
+index 61ad34e..04c21b7 100644
+--- PyInstaller/depend/bindepend.py
++++ PyInstaller/depend/bindepend.py
+@@ -626,9 +626,14 @@ def _getImports_macholib(pth):
+                 # Remove trailing '\x00' characters.
+                 # e.g. '../lib\x00\x00'
+                 rpath = rpath.rstrip('\x00')
++                # Replace the @executable_path and @loader_path keywords
++                # with the actual path to the binary.
++                executable_path = os.path.dirname(pth)
++                rpath = rpath.replace('@executable_path', executable_path)
++                rpath = rpath.replace('@loader_path', executable_path)
+                 # Make rpath absolute. According to Apple doc LC_RPATH
+                 # is always relative to the binary location.
+-                rpath = os.path.normpath(os.path.join(os.path.dirname(pth), rpath))
++                rpath = os.path.normpath(os.path.join(executable_path, rpath))
+                 run_paths.update([rpath])
+             else:
+                 # Frameworks that have this structure Name.framework/Versions/N/Name

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,12 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   md5: ad924928983014e6b8ce5422d7687832
   patches:
+    # Fixes an issue where libraries with @rpath set
+    # on OS X could not be found.
+    #
+    # https://github.com/pyinstaller/pyinstaller/pull/1965
+    #
+    - PR_1965.diff
     # Fixes an issue where libpython would not be found
     # if it had a suffix (e.g. `m`). The PR used is
     # linked below.
@@ -19,7 +25,7 @@ source:
     - PR_1971.diff
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   features:
     - vc9     # [win and py27]


### PR DESCRIPTION
This adds a patch to PyInstaller to better work with libraries that use `@rpath` on OS X. As a result, this is very useful when working with `conda` packages. See this issue ( https://github.com/pyinstaller/pyinstaller/issues/1514 ) for some history on the problem. The patch added comes from PR ( https://github.com/pyinstaller/pyinstaller/pull/1965 ), which seems to fix this problem for me with `libpython` on OS X. This issue had been affecting my ability to build [statuspage]( https://github.com/jayfk/statuspage ) ( https://github.com/conda-forge/staged-recipes/pull/775 ) locally.