### PR TITLE
Pickup our libz on OS X

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - PR_1971.diff
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   features:
     - vc9     # [win and py27]
@@ -33,7 +33,7 @@ build:
     - pyi-makespec = PyInstaller.utils.cliutils.makespec:run
     - pyi-set_version = PyInstaller.utils.cliutils.set_version:run
   script:
-    - export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"               # [linux]
+    - export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"               # [unix]
     - pushd bootloader
     - waf --prefix="${PREFIX}" --clang distclean all            # [osx]
     - waf --prefix="${PREFIX}" --gcc --no-lsb distclean all     # [linux]


### PR DESCRIPTION
Fixes https://github.com/conda-forge/pyinstaller-feedstock/issues/3

Here we use the same workaround that we used to pickup `libz` on Linux to ensure we pickup our `libz` on OS X. This seems to work correctly.