### PR TITLE
Re-render 2.1.1, macOS Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,18 @@ env:
     
     - CONDA_PY=27
     - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "jWjXyc1O09gNItewPj3u6JdPqEW06LjhWrZvWFSxdDadSFE2DPllL25N2/yVQ7BbapkB7bv3yhFMT3oo8cL3H2naXZy+FKSZ9iW38RiE/5C6Mwd9WtlwH7xxG2OV6u1qrjP5kO0yqcMnwbQQIhJJbRWlpFnMOwPTnjKYJXUGvQ+tY7ku5iKf3W3tXLqzAE4X2fZS7FTdglXZhz9ET2aUql/oppJZehb50tgJvp3LagMsnyI7Oyz/XmDcemLRqf6WSG99egAyuSldvCs7LzRoCv6EdqryVDXwg6n9w86odHIsZUqYZ0PDY+dwk8mS03+32CSBgiKr0445MPbXgynpcL7e6VclSSpOWqy4Exp8uiIooa8tRf5fBQjNCbGQ3bIwTBG16sSnsaTNWapSzIpJ5NQlTRl712SZqvCbig+NAFVIOYcEpLtrWshWljhtRim9Yj7zz5WFux671cZNgKtCdZ1TuhjK/06+oSCsbxG6ajFD+0U/L5Gm8ZUBRKc3oz/gtKhsENMUwtD2yaq4Hh3Wa/yI6AIUBUxsoLtI799uzCUagxjaE7WmNSqxWOg6JNM26laeHQa8bE6Lax0hbwIeWmkPI7VkmLrp7UvXK6LXmawJNXHJIEg3g4t+G1cNAkGYOMWO1tRfaKZNChLyZti18N7YRLSCbza0sUwmCKuxqRU="
 
 
 before_install:
+    # Fast finish the PR.
+    - |
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+
     # Remove homebrew.
     - |
       echo ""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,14 +46,10 @@ platform:
 
 install:
     # If there is a newer build queued for the same PR, cancel this one.
-    # The AppVeyor 'rollout builds' option is supposed to serve the same
-    # purpose but it is problematic because it tends to cancel builds pushed
-    # directly to master instead of just PR builds (or the converse).
-    # credits: JuliaLang developers.
-    - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-          throw "There are newer queued builds for this pull request, failing early." }
+    - cmd: |
+        curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py > ff_ci_pr_build.py
+        ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
+        del ff_ci_pr_build.py
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q

--- a/ci_support/fast_finish_ci_pr_build.sh
+++ b/ci_support/fast_finish_ci_pr_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,12 +24,14 @@ show_channel_urls: true
 CONDARC
 )
 
+rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
+
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
-                        bash || exit $?
+                        bash || exit 1
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
 export PYTHONUNBUFFERED=1
@@ -59,4 +61,11 @@ source run_conda_forge_build_setup
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF
+
+# double-check that the build got to the end
+# see https://github.com/conda-forge/conda-smithy/pull/337
+# for a possible fix
+set -x
+test -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done" || exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 checkout:
   post:
+    - ./ci_support/fast_finish_ci_pr_build.sh
     - ./ci_support/checkout_merge_commit.sh
 
 machine:


### PR DESCRIPTION
In light of issue ( https://github.com/conda-forge/waf-feedstock/issues/5 ), have re-rendered to get Python 3.6 on Mac.