### PR TITLE
Fixes for PyInstaller 3.3, and added test app

### DIFF
--- a/recipe/hello.py
+++ b/recipe/hello.py
@@ -1,0 +1,5 @@
+import sys
+
+print("Hello, World!")
+
+print(sys.executable)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ requirements:
   run:
     - python
     - setuptools
-    - pefile  # [win]
+    - pefile >=2017.9.3 # [win]
     - pycrypto
     - pywin32  # [win]
     - zlib 1.2.*
@@ -69,6 +69,9 @@ test:
     # These are designed for Windows only.
     - pyi-grab_version --help     # [win]
     - pyi-set_version --help      # [win]
+
+  files:
+    - hello.py
 
 about:
   home: http://www.pyinstaller.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ requirements:
   run:
     - python
     - setuptools
-    - pefile >=2017.9.3 # [win]
+    - pefile >=2017.9.3  # [win]
     - pycrypto
     - pywin32  # [win]
     - zlib 1.2.*

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,0 +1,5 @@
+PyInstaller -n hello hello.py
+
+dir dist\hello
+dist\hello\hello.exe
+if errorlevel 1 exit 1

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,4 +1,4 @@
-PyInstaller -n hello hello.py
+pyinstaller -n hello hello.py
 
 dir dist\hello
 dist\hello\hello.exe

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,4 @@
+PyInstaller -n hello hello.py
+
+ls -lh dist/hello
+dist/hello/./hello

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,4 +1,4 @@
-PyInstaller -n hello hello.py
+pyinstaller -n hello hello.py
 
 ls -lh dist/hello
 dist/hello/./hello


### PR DESCRIPTION
This PR makes two changes discussed in https://github.com/conda-forge/pyinstaller-feedstock/issues/13

- Add pefile >=2017.9.3 dependency for windows
- Add a simple test application

I've only tested this on Windows, but hopefully the shell script I wrote will work for Linux/macOS.

Closes #13.