### PR TITLE
Backport fix for setuptools 45.0.0+ compatibility & enable macOS builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,32 +10,28 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_python2.7:
-        CONFIG: linux_python2.7
+      linux_python3.6.____cpython:
+        CONFIG: linux_python3.6.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_python3.6:
-        CONFIG: linux_python3.6
+      linux_python3.7.____cpython:
+        CONFIG: linux_python3.7.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_python3.7:
-        CONFIG: linux_python3.7
-        UPLOAD_PACKAGES: True
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_aarch64_python3.6:
-        CONFIG: linux_aarch64_python3.6
+      linux_aarch64_python3.6.____cpython:
+        CONFIG: linux_aarch64_python3.6.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-aarch64
-      linux_aarch64_python3.7:
-        CONFIG: linux_aarch64_python3.7
+      linux_aarch64_python3.7.____cpython:
+        CONFIG: linux_aarch64_python3.7.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-aarch64
-      linux_ppc64le_python3.6:
-        CONFIG: linux_ppc64le_python3.6
+      linux_ppc64le_python3.6.____cpython:
+        CONFIG: linux_ppc64le_python3.6.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
-      linux_ppc64le_python3.7:
-        CONFIG: linux_ppc64le_python3.7
+      linux_ppc64le_python3.7.____cpython:
+        CONFIG: linux_ppc64le_python3.7.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-ppc64le
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,19 +5,16 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.13
+    vmImage: macOS-10.14
   timeoutInMinutes: 360
   strategy:
     maxParallel: 8
     matrix:
-      osx_python2.7:
-        CONFIG: osx_python2.7
+      osx_python3.6.____cpython:
+        CONFIG: osx_python3.6.____cpython
         UPLOAD_PACKAGES: True
-      osx_python3.6:
-        CONFIG: osx_python3.6
-        UPLOAD_PACKAGES: True
-      osx_python3.7:
-        CONFIG: osx_python3.7
+      osx_python3.7.____cpython:
+        CONFIG: osx_python3.7.____cpython
         UPLOAD_PACKAGES: True
 
   steps:
@@ -41,15 +38,15 @@ jobs:
 
   - script: |
       source activate base
-      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build shyaml
+      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
     displayName: 'Add conda-forge-ci-setup=2'
 
   - script: |
       source activate base
       echo "Configuring conda."
 
-      setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
-
+      setup_conda_rc ./ "./recipe" ./.ci_support/${CONFIG}.yaml
+      export CI=azure
       source run_conda_forge_build_setup
       conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
     env: {
@@ -59,23 +56,24 @@ jobs:
 
   - script: |
       source activate base
-      mangle_compiler ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      mangle_compiler ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Mangle compiler
 
   - script: |
       source activate base
-      make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      make_build_number ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Generate build number clobber file
 
   - script: |
       source activate base
-      conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+      conda build "./recipe" -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
     displayName: Build recipe
 
   - script: |
       source activate base
-      upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
-    displayName: Upload recipe
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      upload_package ./ "./recipe" ./.ci_support/${CONFIG}.yaml
+    displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -20,60 +20,10 @@ jobs:
   steps:
   # TODO: Fast finish on azure pipelines?
   - script: |
-      echo "Fast Finish"
-      
-
-  - script: |
-      echo "Removing homebrew from Azure to avoid conflicts."
-      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
-      chmod +x ~/uninstall_homebrew
-      ~/uninstall_homebrew -fq
-      rm ~/uninstall_homebrew
-    displayName: Remove homebrew
-
-  - bash: |
-      echo "##vso[task.prependpath]$CONDA/bin"
-      sudo chown -R $USER $CONDA
-    displayName: Add conda to PATH
-
-  - script: |
-      source activate base
-      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
-    displayName: 'Add conda-forge-ci-setup=2'
-
-  - script: |
-      source activate base
-      echo "Configuring conda."
-
-      setup_conda_rc ./ "./recipe" ./.ci_support/${CONFIG}.yaml
       export CI=azure
-      source run_conda_forge_build_setup
-      conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
-    env: {
-      OSX_FORCE_SDK_DOWNLOAD: "1"
-    }
-    displayName: Configure conda and conda-build
-
-  - script: |
-      source activate base
-      mangle_compiler ./ "./recipe" ./.ci_support/${CONFIG}.yaml
-    displayName: Mangle compiler
-
-  - script: |
-      source activate base
-      make_build_number ./ "./recipe" ./.ci_support/${CONFIG}.yaml
-    displayName: Generate build number clobber file
-
-  - script: |
-      source activate base
-      conda build "./recipe" -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-    displayName: Build recipe
-
-  - script: |
-      source activate base
+      export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
-      upload_package ./ "./recipe" ./.ci_support/${CONFIG}.yaml
-    displayName: Upload package
+      ./.scripts/run_osx_build.sh
+    displayName: Run OSX build
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -60,30 +60,31 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=2' # Optional
+        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=3 pip' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment
 
     - script: set PYTHONUNBUFFERED=1
+      displayName: Set PYTHONUNBUFFERED
 
     # Configure the VM
-    - script: setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+    - script: |
+        call activate base
+        setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+      displayName: conda-forge CI setup
 
     # Configure the VM.
     - script: |
         set "CI=azure"
+        call activate base
         run_conda_forge_build_setup
       displayName: conda-forge build setup
     
 
-    - script: |
-        rmdir C:\strawberry /s /q
-      continueOnError: true
-      displayName: remove strawberryperl
-
     # Special cased version setting some more things!
     - script: |
+        call activate base
         conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe (vs2008)
       env:
@@ -92,6 +93,7 @@ jobs:
       condition: contains(variables['CONFIG'], 'vs2008')
 
     - script: |
+        call activate base
         conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe
       env:
@@ -100,7 +102,8 @@ jobs:
 
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
-        upload_package .\ ".\recipe" .ci_support\%CONFIG%.yaml
+        call activate base
+        upload_package  .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -10,16 +10,12 @@ jobs:
   strategy:
     maxParallel: 4
     matrix:
-      win_c_compilervs2008python2.7:
-        CONFIG: win_c_compilervs2008python2.7
+      win_python3.6.____cpython:
+        CONFIG: win_python3.6.____cpython
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
-      win_c_compilervs2015python3.6:
-        CONFIG: win_c_compilervs2015python3.6
-        CONDA_BLD_PATH: D:\\bld\\
-        UPLOAD_PACKAGES: True
-      win_c_compilervs2015python3.7:
-        CONFIG: win_c_compilervs2015python3.7
+      win_python3.7.____cpython:
+        CONFIG: win_python3.7.____cpython
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
   steps:
@@ -66,13 +62,13 @@ jobs:
       inputs:
         packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=2' # Optional
         installOptions: "-c conda-forge"
-        updateConda: false
+        updateConda: true
       displayName: Install conda-build and activate environment
 
     - script: set PYTHONUNBUFFERED=1
 
     # Configure the VM
-    - script: setup_conda_rc .\ .\recipe .\.ci_support\%CONFIG%.yaml
+    - script: setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
 
     # Configure the VM.
     - script: |
@@ -88,7 +84,7 @@ jobs:
 
     # Special cased version setting some more things!
     - script: |
-        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe (vs2008)
       env:
         VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
@@ -96,7 +92,7 @@ jobs:
       condition: contains(variables['CONFIG'], 'vs2008')
 
     - script: |
-        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1
@@ -104,7 +100,7 @@ jobs:
 
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
-        upload_package .\ .\recipe .ci_support\%CONFIG%.yaml
+        upload_package .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.ci_support/linux_aarch64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.6.____cpython.yaml
@@ -9,7 +9,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge,c4aarch64,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
@@ -21,6 +21,6 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.7'
+- 3.6.* *_cpython
 zlib:
 - '1.2'

--- a/.ci_support/linux_aarch64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.7.____cpython.yaml
@@ -1,13 +1,19 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '7'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- condaforge/linux-anvil-aarch64
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -15,6 +21,6 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.7'
+- 3.7.* *_cpython
 zlib:
 - '1.2'

--- a/.ci_support/linux_ppc64le_python3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.6.____cpython.yaml
@@ -1,9 +1,13 @@
 c_compiler:
-- vs2008
+- gcc
+c_compiler_version:
+- '8'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+docker_image:
+- condaforge/linux-anvil-ppc64le
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -11,9 +15,6 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '2.7'
-zip_keys:
-- - python
-  - c_compiler
+- 3.6.* *_cpython
 zlib:
 - '1.2'

--- a/.ci_support/linux_ppc64le_python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.7.____cpython.yaml
@@ -1,13 +1,13 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '8'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-ppc64le
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -15,6 +15,6 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.7'
+- 3.7.* *_cpython
 zlib:
 - '1.2'

--- a/.ci_support/linux_python3.6.____cpython.yaml
+++ b/.ci_support/linux_python3.6.____cpython.yaml
@@ -1,9 +1,13 @@
 c_compiler:
-- vs2015
+- gcc
+c_compiler_version:
+- '7'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -11,9 +15,6 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.6'
-zip_keys:
-- - python
-  - c_compiler
+- 3.6.* *_cpython
 zlib:
 - '1.2'

--- a/.ci_support/linux_python3.7.____cpython.yaml
+++ b/.ci_support/linux_python3.7.____cpython.yaml
@@ -1,13 +1,13 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '7'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -15,6 +15,6 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.6'
+- 3.7.* *_cpython
 zlib:
 - '1.2'

--- a/.ci_support/osx_python3.6.____cpython.yaml
+++ b/.ci_support/osx_python3.6.____cpython.yaml
@@ -1,19 +1,17 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '9'
 channel_sources:
-- conda-forge,c4aarch64,defaults
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
-docker_image:
-- condaforge/linux-anvil-aarch64
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -21,6 +19,6 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.6'
+- 3.6.* *_cpython
 zlib:
 - '1.2'

--- a/.ci_support/osx_python3.7.____cpython.yaml
+++ b/.ci_support/osx_python3.7.____cpython.yaml
@@ -1,13 +1,17 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
+- '9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-docker_image:
-- condaforge/linux-anvil-comp7
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -15,6 +19,6 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '2.7'
+- 3.7.* *_cpython
 zlib:
 - '1.2'

--- a/.ci_support/win_python3.6.____cpython.yaml
+++ b/.ci_support/win_python3.6.____cpython.yaml
@@ -1,5 +1,5 @@
 c_compiler:
-- vs2015
+- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/win_python3.6.____cpython.yaml
+++ b/.ci_support/win_python3.6.____cpython.yaml
@@ -1,13 +1,9 @@
 c_compiler:
-- gcc
-c_compiler_version:
-- '7'
+- vs2015
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-docker_image:
-- condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -15,6 +11,6 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.6'
+- 3.6.* *_cpython
 zlib:
 - '1.2'

--- a/.ci_support/win_python3.7.____cpython.yaml
+++ b/.ci_support/win_python3.7.____cpython.yaml
@@ -1,5 +1,5 @@
 c_compiler:
-- vs2015
+- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/win_python3.7.____cpython.yaml
+++ b/.ci_support/win_python3.7.____cpython.yaml
@@ -11,9 +11,6 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.7'
-zip_keys:
-- - python
-  - c_compiler
+- 3.7.* *_cpython
 zlib:
 - '1.2'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hadim @jakirkham @nicoddemus
+* @hadim @jakirkham @nehaljwani @nicoddemus

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+on:
+  status: {}
+  check_suite:
+    types:
+      - completed
+
+jobs:
+  regro-cf-autotick-bot-action:
+    runs-on: ubuntu-latest
+    name: regro-cf-autotick-bot-action
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: regro-cf-autotick-bot-action
+        id: regro-cf-autotick-bot-action
+        uses: regro/cf-autotick-bot-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/webservices.yml
+++ b/.github/workflows/webservices.yml
@@ -1,0 +1,12 @@
+on: repository_dispatch
+
+jobs:
+  webservices:
+    runs-on: ubuntu-latest
+    name: webservices
+    steps:
+      - name: webservices
+        id: webservices
+        uses: conda-forge/webservices-dispatch-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -19,7 +19,8 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
+conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
+
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -33,7 +34,7 @@ conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    upload_package  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -52,8 +52,10 @@ mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 
+# Allow people to specify extra default arguments to `docker run` (e.g. `--rm`)
+DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
-    DOCKER_RUN_ARGS="-it "
+    DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -x
+
+echo -e "\n\nInstalling a fresh version of Miniforge."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:install_miniforge\\r'
+fi
+MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
+MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
+curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
+bash $MINIFORGE_FILE -b
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:install_miniforge\\r'
+fi
+
+echo -e "\n\nConfiguring conda."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:configure_conda\\r'
+fi
+
+source ${HOME}/miniforge3/etc/profile.d/conda.sh
+conda activate base
+
+echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
+conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+
+
+
+echo -e "\n\nSetting up the condarc and mangling the compiler."
+setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+
+echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+/usr/bin/sudo mangle_homebrew
+/usr/bin/sudo -k
+
+echo -e "\n\nRunning the build setup script."
+source run_conda_forge_build_setup
+
+
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:configure_conda\\r'
+fi
+
+set -e
+
+echo -e "\n\nMaking the build clobber file and running the build."
+make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+  echo -e "\n\nUploading the packages."
+  upload_package  ./ ./recipe ./.ci_support/${CONFIG}.yaml
+fi

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About pyinstaller
 
 Home: http://www.pyinstaller.org
 
-Package license: GPL 2
+Package license: GPL-2.0-or-later
 
 Feedstock license: BSD 3-Clause
 

--- a/README.md
+++ b/README.md
@@ -29,85 +29,79 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_aarch64_python3.6</td>
+              <td>linux_aarch64_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=882&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_python3.7</td>
+              <td>linux_aarch64_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=882&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python3.6</td>
+              <td>linux_ppc64le_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=882&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python3.7</td>
+              <td>linux_ppc64le_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=882&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python2.7</td>
+              <td>linux_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=882&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=linux&configuration=linux_python2.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.6</td>
+              <td>linux_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=882&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.7</td>
+              <td>osx_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=882&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2008python2.7</td>
+              <td>osx_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=882&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2008python2.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015python3.6</td>
+              <td>win_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=882&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=win&configuration=win_python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015python3.7</td>
+              <td>win_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=882&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinstaller-feedstock?branchName=master&jobName=win&configuration=win_python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr>
           </tbody>
         </table>
       </details>
-    </td>
-  </tr>
-  <tr>
-    <td>OSX</td>
-    <td>
-      <img src="https://img.shields.io/badge/OSX-disabled-lightgrey.svg" alt="OSX disabled">
     </td>
   </tr>
 </table>
@@ -206,5 +200,6 @@ Feedstock Maintainers
 
 * [@hadim](https://github.com/hadim/)
 * [@jakirkham](https://github.com/jakirkham/)
+* [@nehaljwani](https://github.com/nehaljwani/)
 * [@nicoddemus](https://github.com/nicoddemus/)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,4 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
+  - template: ./.azure-pipelines/azure-pipelines-osx.yml
   - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/recipe/0002-Bootloader-build-Fallback-to-a-default-min-macOS-ver.patch
+++ b/recipe/0002-Bootloader-build-Fallback-to-a-default-min-macOS-ver.patch
@@ -1,0 +1,69 @@
+From c2ac293fb4434a508663c6c679831500934d2aec Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Sun, 15 Mar 2020 04:54:04 -0400
+Subject: [PATCH 2/2] Bootloader build: Fallback to a default min macOS
+ version.
+
+This allows end users to target a different macOS version using the environment
+variable MACOSX_DEPLOYMENT_TARGET and specifying -mmacosx-version-min in
+CPPFLAGS/CFLAGS and LDFLAGS/LINKFLAGS
+---
+ bootloader/wscript          | 11 ++++++++---
+ doc/bootloader-building.rst |  2 ++
+ news/4677.build.rst         |  2 ++
+ 3 files changed, 12 insertions(+), 3 deletions(-)
+ create mode 100644 news/4677.build.rst
+
+diff --git a/bootloader/wscript b/bootloader/wscript
+index 50c297c4..77e8a352 100644
+--- a/bootloader/wscript
++++ b/bootloader/wscript
+@@ -544,7 +544,8 @@ def configure(ctx):
+         # The following variable fixes 10.7 compatibility.
+         # According to OS X doc this variable is equivalent to gcc option:
+         #   -mmacosx-version-min=10.7
+-        os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.7'
++        if not os.environ.get('MACOSX_DEPLOYMENT_TARGET'):
++            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.7'
+ 
+     ### Libraries
+ 
+@@ -629,8 +630,12 @@ def configure(ctx):
+             ctx.env.append_value('LINKFLAGS', '-municode')
+ 
+     if ctx.env.DEST_OS == 'darwin':
+-        ctx.env.append_value('CFLAGS', '-mmacosx-version-min=10.7')
+-        ctx.env.append_value('LINKFLAGS', '-mmacosx-version-min=10.7')
++        if not any(x for x in ctx.env.CPPFLAGS + ctx.env.CFLAGS
++                   if x.startswith('-mmacosx-version-min=')):
++            ctx.env.append_value('CFLAGS', '-mmacosx-version-min=10.7')
++        if not any(x for x in ctx.env.LDFLAGS + ctx.env.LINKFLAGS
++                   if x.startswith('-mmacosx-version-min=')):
++            ctx.env.append_value('LINKFLAGS', '-mmacosx-version-min=10.7')
+ 
+     # On linux link only with needed libraries.
+     # -Wl,--as-needed is on some platforms detected during configure but
+diff --git a/doc/bootloader-building.rst b/doc/bootloader-building.rst
+index bad26e13..d9920af5 100644
+--- a/doc/bootloader-building.rst
++++ b/doc/bootloader-building.rst
+@@ -121,6 +121,8 @@ Now you can build the bootloader as shown above.
+ Alternatively you may want to use the `darwin64` build-guest
+ provided by the Vagrantfile (see below).
+ 
++By default, the build script targets Mac OSX 10.7, which can be overridden by
++exporting the MACOSX_DEPLOYMENT_TARGET environment variable.
+ 
+ .. _cross-building for mac os x:
+ 
+diff --git a/news/4677.build.rst b/news/4677.build.rst
+new file mode 100644
+index 00000000..636b00db
+--- /dev/null
++++ b/news/4677.build.rst
+@@ -0,0 +1,2 @@
++(OSX) Allow end users to override MACOSX_DEPLOYMENT_TARGET and mmacosx-version-min
++via environment variables and set 10.7 as the fallback value for both.
+-- 
+2.21.0
+

--- a/recipe/0003-hooks-Update-pkg_resources-hook-for-setuptools-v45.0.patch
+++ b/recipe/0003-hooks-Update-pkg_resources-hook-for-setuptools-v45.0.patch
@@ -1,0 +1,35 @@
+From 9c6a859e0445915de4153214bb61f0781c22e01f Mon Sep 17 00:00:00 2001
+From: Hartmut Goebel <h.goebel@crazy-compilers.com>
+Date: Sun, 12 Jan 2020 15:42:26 +0100
+Subject: [PATCH 3/3] hooks: Update pkg_resources hook for setuptools v45.0.0.
+
+---
+ PyInstaller/hooks/hook-pkg_resources.py | 5 +++++
+ news/setuptools45.hooks.rst             | 1 +
+ 2 files changed, 6 insertions(+)
+ create mode 100644 news/setuptools45.hooks.rst
+
+diff --git a/PyInstaller/hooks/hook-pkg_resources.py b/PyInstaller/hooks/hook-pkg_resources.py
+index 3053426d..72ad4835 100644
+--- a/PyInstaller/hooks/hook-pkg_resources.py
++++ b/PyInstaller/hooks/hook-pkg_resources.py
+@@ -14,4 +14,9 @@ from PyInstaller.utils.hooks import collect_submodules
+ # sys.meta_path based import magic to expose them as pkg_resources.extern.*
+ hiddenimports = collect_submodules('pkg_resources._vendor')
+ 
++# pkg_resources v45.0 dropped support for Python 2 and added this
++# module printing a warning. We could save some bytes if we would
++# replace this by a fake module.
++hiddenimports.append('pkg_resources.py2_warn')
++
+ excludedimports = ['__main__']
+diff --git a/news/setuptools45.hooks.rst b/news/setuptools45.hooks.rst
+new file mode 100644
+index 00000000..a4ea719b
+--- /dev/null
++++ b/news/setuptools45.hooks.rst
+@@ -0,0 +1 @@
++Update pkg_resources hook for setuptools v45.0.0.
+-- 
+2.23.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ build:
   script:
     - export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"               # [unix]
     - export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${macos_min_version}"  # [osx]
+    # Remove the pre-compiled bootloaders (available in sdist)
+    - rm -fr ${SRC_DIR}/PyInstaller/bootloader/{Darwin,Linux,Windows}-{64,32}bit  # [unix]
     - pushd bootloader
     - waf --prefix="${PREFIX}" --clang distclean all            # [osx]
     - waf --prefix="${PREFIX}" --gcc --no-lsb distclean all     # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,7 +76,9 @@ test:
 
 about:
   home: http://www.pyinstaller.org
-  license: GPL 2
+  # https://github.com/pyinstaller/pyinstaller/blob/v3.6/COPYING.txt#L11
+  license: GPL-2.0-or-later
+  license_family: GPL
   license_file: COPYING.txt
   summary: PyInstaller bundles a Python application and all its dependencies into a single package.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,3 +85,4 @@ extra:
     - jakirkham
     - nicoddemus
     - hadim
+    - nehaljwani

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,10 @@ source:
   patches:
     - 0001-depend-bindepend-find-statically-linked-libraries.patch
     - 0002-Bootloader-build-Fallback-to-a-default-min-macOS-ver.patch
+    - 0003-hooks-Update-pkg_resources-hook-for-setuptools-v45.0.patch
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - pyinstaller = PyInstaller.__main__:run
     - pyi-archive_viewer = PyInstaller.utils.cliutils.archive_viewer:run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,10 @@ source:
   sha256: {{ sha256 }}
   patches:
     - 0001-depend-bindepend-find-statically-linked-libraries.patch
+    - 0002-Bootloader-build-Fallback-to-a-default-min-macOS-ver.patch
 
 build:
   number: 0
-  skip: True  # [osx]
   entry_points:
     - pyinstaller = PyInstaller.__main__:run
     - pyi-archive_viewer = PyInstaller.utils.cliutils.archive_viewer:run
@@ -25,6 +25,7 @@ build:
     - pyi-set_version = PyInstaller.utils.cliutils.set_version:run
   script:
     - export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"               # [unix]
+    - export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${macos_min_version}"  # [osx]
     - pushd bootloader
     - waf --prefix="${PREFIX}" --clang distclean all            # [osx]
     - waf --prefix="${PREFIX}" --gcc --no-lsb distclean all     # [linux]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Fixes #32 