### PR TITLE
Impose minimum version of importlib-metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,9 +286,9 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 0002-don-t-set-arch.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<35 or py>39]
   entry_points:
     - pyinstaller = PyInstaller.__main__:run
@@ -59,7 +59,7 @@ requirements:
     - macholib >=1.8
     - pyinstaller-hooks-contrib >=2020.6
     - setuptools  # due to pkg_resources import
-    - importlib-metadata  # [py<38]
+    - importlib-metadata >=0.8  # [py<38]
 
 test:
   imports:


### PR DESCRIPTION
Should prevent a recurrence of pyinstaller/pyinstaller#5521 which was caused by a too old version of importlib-metadata.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Closes pyinstaller/pyinstaller#5521.

<!--
Please add any other relevant info below:
-->

I've no idea what this build number is about? The [link in the readme](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string) is dead.
