### PR TITLE
Statically link zlib

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-don-t-set-arch.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37 or py>310]
   entry_points:
     - pyinstaller = PyInstaller.__main__:run
@@ -23,6 +23,7 @@ build:
     - pyi-makespec = PyInstaller.utils.cliutils.makespec:run
     - pyi-set_version = PyInstaller.utils.cliutils.set_version:run
   script:
+    - export PYI_STATIC_ZLIB=1  # [unix]
     - export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"               # [unix]
     - export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"  # [osx]
     # Remove the pre-compiled bootloaders (available in sdist)


### PR DESCRIPTION
I've noticed that `conda-standalone` dynamically links to `libz`  which can cause issues on some systems (see https://github.com/conda/constructor/pull/492). `pyinstaller` now has an option to link statically when building `zlib` for it's bootstrap executable by setting `PYI_STATIC_ZLIB`. I don't think there is any real downside in doing.

Any thoughts?

@conda-forge-admin, please rerender