### PR TITLE
resync with upstream dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-don-t-set-arch.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37 or py>310]
   entry_points:
     - pyinstaller = PyInstaller.__main__:run
@@ -58,11 +58,11 @@ requirements:
   run:
     - altgraph
     - python
-    - pefile >=2017.8.1       # [win]
+    - pefile >=2022.5.30      # [win]
     - pywin32                 # [win]
     - pywin32-ctypes >=0.2.0  # [win]
     - macholib >=1.8
-    - pyinstaller-hooks-contrib >=2020.6
+    - pyinstaller-hooks-contrib >=2021.4
     - setuptools  # due to pkg_resources import
     - importlib-metadata >=0.8  # [py<38]
 


### PR DESCRIPTION
The `pefile` version in particular is important because PyInstaller now uses a context manager which wasn't included in older pefile releases.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

[Upstream `setup.cfg` at the 5.6.2 release](https://github.com/pyinstaller/pyinstaller/blame/09b8a1ebd0a62c4e61de61cd33c739c997249a89/setup.cfg#L64)

@conda-forge-admin, please rerender
